### PR TITLE
remember export directory

### DIFF
--- a/src/interface/VizBin/src/lu/uni/lcsb/vizbin/DataExporter.java
+++ b/src/interface/VizBin/src/lu/uni/lcsb/vizbin/DataExporter.java
@@ -30,6 +30,8 @@ import lcsb.vizbin.data.Sequence;
  */
 public class DataExporter {
 
+  private static String lastUsedDirectory = null;
+
 	public static File exportCluster(JFrame parentFrame, String inFileName, List<Sequence> sequenceList) {
 		File outFile = null;
 		File inFile = new File(inFileName);
@@ -123,13 +125,14 @@ public class DataExporter {
 	}
 
 	private static File getSelectedFile() {
-		final JFileChooser fc = new JFileChooser();
+		final JFileChooser fc = new JFileChooser(lastUsedDirectory);
 		fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
 		fc.setMultiSelectionEnabled(false);
 		int returnVal = fc.showSaveDialog(null);
 		if (fc.getSelectedFile() == null)
 			return null;
 		else {
+      lastUsedDirectory = fc.getSelectedFile().getParent();
 			if (fc.getSelectedFile().exists()) {
 				returnVal = JOptionPane.showConfirmDialog(
 						null, "The file you specified already exists, do you wish to overwrite it?", "Confirm overwrite", JOptionPane.YES_NO_OPTION);


### PR DESCRIPTION
The directory that the bins are exported to is remembered since
it's likely that different bins from the same sample will go into
the same directory.

This should hopefully save some clicks since the exporter won't
default to using the home directory over and over